### PR TITLE
View navigation history

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,11 @@
     "gradlew",
     "jacoco",
     "Newify",
+    "Noln",
+    "outln",
     "powerassert",
     "rint",
+    "sprintf",
     "starbase"
   ]
 }

--- a/src/main/groovy/net/ebdon/trk21/Coords2d.groovy
+++ b/src/main/groovy/net/ebdon/trk21/Coords2d.groovy
@@ -18,7 +18,6 @@ import groovy.transform.*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@ToString(includePackage=false,includeNames=true,excludes='valid')
 @AutoClone
 @Canonical @TypeChecked
 final class Coords2d {
@@ -27,6 +26,10 @@ final class Coords2d {
 
   boolean isValid() {
     row > 0 && col > 0
+  }
+
+  String toString() {
+    "$col - $row"
   }
 
   List<Integer> toList() {

--- a/src/main/groovy/net/ebdon/trk21/Trek.groovy
+++ b/src/main/groovy/net/ebdon/trk21/Trek.groovy
@@ -38,6 +38,8 @@ import net.ebdon.trk21.course_man.ShipCourseManager;
 final class Trek extends LoggingBase {
   static String logPositionPieces = 'Positioning game pieces {} in quadrant {}'
 
+  static List<Coords2d> trackLog = [ ]
+
   UiBase ui;
   PropertyResourceBundle rb;
   MessageFormat formatter;
@@ -131,6 +133,7 @@ final class Trek extends LoggingBase {
   @TypeChecked
   void startGame() {
     shortRangeScan()
+    trackLog << ship.position.quadrant.clone()
   }
 
   /// @deprecated Not needed with new font config.
@@ -154,8 +157,35 @@ final class Trek extends LoggingBase {
     if ( scm.setOffFrom( quadrant ) ) {
       repopulateSector oldQuadrant
       shortRangeScan()
+      updateTrackLog()
     }
   }
+
+  void updateTrackLog() {
+    Coords2d newQuadrant = ship.position.quadrant
+    log.trace "Before if: $trackLog"
+    log.trace "newQuadrant is: $newQuadrant"
+    if (newQuadrant != trackLog.last() ) {
+      log.trace 'HAVE moved quadrant, about to clone and log'
+      trackLog << newQuadrant.clone()
+    } else {
+      log.trace 'Have NOT moved quadrant'
+    }
+    log.trace "After if: $trackLog"
+  }
+
+  @TypeChecked
+  void showHistory() {
+    final int maxReportCols = 5
+    log.trace "Showing history for ${trackLog.size()} trackLog entries"
+    trackLog.eachWithIndex { Coords2d quadrantCoords, int index ->
+      ui.fmtMsgNoln 'trek.historyEntry', [ quadrantCoords.toString(), ]
+
+      if (index % maxReportCols == maxReportCols - 1) { // -1 as index starts at 0
+        ui.outln ''
+      }
+    }
+   }
 
   @TypeChecked
   private void repopulateSector( final Coords2d oldQuadrant ) {

--- a/src/main/groovy/net/ebdon/trk21/TrekCli.groovy
+++ b/src/main/groovy/net/ebdon/trk21/TrekCli.groovy
@@ -57,6 +57,7 @@ class TrekCli extends UiBase {
         case 'p': trek.firePhasers(); break
         case 'd': trek.reportDamage();  break
         case 'n': trek.navComp();  break
+        case 'h': trek.showHistory();  break
         case 'q': outln '\nBye!\n'; finished = true; trek = null; break
         default: println 'What?'
       }

--- a/src/main/groovy/net/ebdon/trk21/UiBase.groovy
+++ b/src/main/groovy/net/ebdon/trk21/UiBase.groovy
@@ -45,6 +45,11 @@ abstract class UiBase extends LoggingBase { /// @todo LoggingBase required for c
     outln String.format( getPrompt( formatId ), *args )
   }
 
+  @groovy.transform.TypeChecked
+  void fmtMsgNoln( final String formatId, final List<Object> args ) {
+    print String.format( getPrompt( formatId ), *args )
+  }
+
   final String pleaseEnterNumber() {
     getPrompt( 'input.err.enterNumber' )
   }

--- a/src/main/resources/Language.properties
+++ b/src/main/resources/Language.properties
@@ -91,7 +91,7 @@ phaser.refused.badEnergy  = Phaser command refused - insufficient energy availab
 phaserControl.disabled = Phaser control is disabled.
 phaserControl.onTarget = Phasers locked in on target. Energy available %1$d
 
-deviceStatusLottery.spaceStorm = *** Space Storm, {0} damaged ***"
+deviceStatusLottery.spaceStorm = *** Space Storm, {0} damaged ***
 
 engine.damaged      = Warp engines are damaged.
 engine.damaged.max  = Maximum speed is .2
@@ -106,6 +106,7 @@ battle.targetEnergyLeft = \t(%1$d left)\n
 
 enemyFleet.hitOnFedShip =  Hit from Klingon at sector %2$d - %1$d
 
+trek.historyEntry = Q: %1$s |\u0020
 trek.victoryDance = \
 \nIt is stardate %1$d\n \
 The last Klingon battle cruiser in the galaxy has been destroyed.\n \

--- a/src/test/groovy/net/ebdon/trk21/LongRangeScanTest.groovy
+++ b/src/test/groovy/net/ebdon/trk21/LongRangeScanTest.groovy
@@ -22,6 +22,7 @@ import groovy.test.GroovyTestCase
 
 @Newify( [MockFor,Coords2d] )
 final class LongRangeScanTest extends GroovyTestCase {
+  private final String quadScanResult = '!!!'
   private MockFor dcMock;
   private MockFor galaxyMock;
   private Coords2d shipQuad;
@@ -52,7 +53,8 @@ final class LongRangeScanTest extends GroovyTestCase {
   }
 
   void testOnline() {
-    galaxyMock.demand.scan(9) { int row, int col -> 'scan' }
+    final String scanLine = "  $quadScanResult" * 3 + '\n'
+    galaxyMock.demand.scan(9) { int row, int col -> quadScanResult }
 
     dcMock.demand.isDamaged { false }
 
@@ -65,6 +67,6 @@ final class LongRangeScanTest extends GroovyTestCase {
 
     assert ui.localMsgLog == ['sensors.longRange.scanQuadrant']
     assert ui.argsLog     == [ [1,1] ]
-    assert ui.msgLog      == ['  scan' * 3] * 3
+    assert ui.msgLog      == [ scanLine ] * 3
   }
 }

--- a/src/test/groovy/net/ebdon/trk21/ShortRangeScanTest.groovy
+++ b/src/test/groovy/net/ebdon/trk21/ShortRangeScanTest.groovy
@@ -102,7 +102,7 @@ final class ShortRangeScanTest extends TrekTestBase {
         assert localMsgLog[it] == "sensors.shipStatus.${it - 1}"
       }
 
-      assert msgLog == [dummyQuadRow] * rowsInQuad
+      assert msgLog == ["$dummyQuadRow\n"] * rowsInQuad
     }
   }
 }

--- a/src/test/groovy/net/ebdon/trk21/TestUi.groovy
+++ b/src/test/groovy/net/ebdon/trk21/TestUi.groovy
@@ -47,8 +47,9 @@ final class TestUi extends UiBase {
     key
   }
 
-  void outln( String str ) {
-    msgLog << str
+  @groovy.transform.TypeChecked
+  @Override void outln( String str ) {
+    msgLog << str + '\n'
   }
 
   void localMsg( final String msgId ) {
@@ -60,6 +61,11 @@ final class TestUi extends UiBase {
     assert args
     localMsgLog << formatId
     argsLog << args
+  }
+
+  @groovy.transform.TypeChecked
+  @Override void fmtMsgNoln( final String formatId, final List<Object> args ) {
+    fmtMsg formatId, args
   }
 
   @SuppressWarnings('UnusedMethodParameter')

--- a/src/test/groovy/net/ebdon/trk21/TrekTest.groovy
+++ b/src/test/groovy/net/ebdon/trk21/TrekTest.groovy
@@ -34,6 +34,7 @@ final class TrekTest extends GroovyTestCase {
     logger.info 'setUp'
     Trek.config = true
     trek = new Trek()
+    trek.trackLog.clear()
   }
 
   @Newify([Position,Coords2d])
@@ -100,15 +101,89 @@ final class TrekTest extends GroovyTestCase {
     }
   }
 
+  void testShowHistory() {
+    logger.info '> testShowHistory'
+    final String lastQuadrantString = 'F - U'
+    final String historyFormatId = 'trek.historyEntry'
+    final int numQuadrantsToVisit = 6
+    final int numQuadrantsPerLine = 5
+    final int numQuadrantCoordToStrings = (1..numQuadrantsToVisit).sum()
+
+    char row
+    char col
+
+    UiBase ui            = new TestUi()
+    MockFor coords2dMock = MockFor( Coords2d )
+    coords2dMock.demand.toString(numQuadrantCoordToStrings) {
+      String rv = "${row++} - ${col--}"
+      logger.info "Coords2dMock.toString() returning $rv"
+      rv
+    }
+
+    trek.ui = ui
+    coords2dMock.use {
+      1.upto(numQuadrantsToVisit) { int numQuadrantsVisited ->
+        ui.msgLog = [ ]
+        ui.localMsgLog = [ ]
+        logger.debug sprintf( 'Visit %1d: %2d messages, %1d quadrants.%n',
+          numQuadrantsVisited, ui.msgLog.size(), trek.trackLog.size()
+        )
+        trek.trackLog << new Coords2d()
+        row = 'A'
+        col = 'Z'
+        trek.showHistory()
+        assert ui.localMsgLog.size() == numQuadrantsVisited
+        assert ui.localMsgLog.last() == historyFormatId
+        assert numQuadrantsVisited in 1..numQuadrantsToVisit
+
+        switch (numQuadrantsVisited) {
+          case 1.. numQuadrantsPerLine - 1 -> {
+            assert ui.msgLog.size() == 0
+          }
+          case numQuadrantsPerLine -> {
+            assert ui.msgLog.size() == 1
+            assert ui.msgLog.first() == '\n'
+          }
+          case numQuadrantsPerLine..numQuadrantsToVisit -> {
+            assert ui.msgLog.size() == 1
+            assert ui.msgLog.first() == '\n'
+          }
+        }
+      }
+    }
+    assert ui.localMsgLog.last() == historyFormatId
+    assert ui.argsLog.last() == [ lastQuadrantString, ]
+    logger.info '< testShowHistory'
+  }
+
   void testStartGame() {
-    UiBase ui = new TestUi()
+    UiBase ui             = new TestUi()
+    MockFor shipMock      = MockFor( FederationShip )
+    MockFor coords2dMock  = MockFor( Coords2d )
+    MockFor positionMock  = MockFor( Position)
     MockFor damageControl = MockFor( DamageControl )
+
     damageControl.demand.isDamaged { true }
 
-    damageControl.use {
-      trek.damageControl = new DamageControl()
-      trek.ui = ui
-      trek.startGame()
+    coords2dMock.demand.with {
+      clone { }
+    }
+
+    coords2dMock.use {
+      positionMock.demand.getQuadrant { new Coords2d() }
+
+      positionMock.use {
+        shipMock.demand.getPosition { new Position() }
+
+        shipMock.use {
+          damageControl.use {
+            trek.ship = new FederationShip()
+            trek.damageControl = new DamageControl()
+            trek.ui = ui
+            trek.startGame()
+          }
+        }
+      }
     }
 
     assert ui.localMsgLog == ['sensors.shortRange.offline']
@@ -163,5 +238,39 @@ final class TrekTest extends GroovyTestCase {
 
     assert ui.localMsgLog == ['trek.funeral']
     assert ui.argsLog.first() == [solarYear, timePlayed, numEnemyNotDestroyed]
+  }
+
+  @Newify(Coords2d)
+  void testUpdateTrackLog() {
+    logger.info '> testUpdateTrackLog'
+
+    MockFor shipMock = MockFor(FederationShip)
+    final int move1QuadRow = 3
+    final int move1QuadCol = 5
+
+    final Coords2d mockQuadrant = Coords2d(move1QuadRow,move1QuadCol)
+    final Position mockPosition = new Position(mockQuadrant, Coords2d(2, 4))
+
+    shipMock.demand.getPosition(2) { mockPosition }
+
+    shipMock.use {
+      trek.ship = new FederationShip()
+
+      // There will be one entry at game start
+      trek.trackLog = [ Coords2d(1, 1) ]
+      assert trek.trackLog.size() == 1
+
+      trek.updateTrackLog() // Log move to different quadrant
+      assert trek.trackLog.size() == 2
+
+      final Coords2d loggedQuadrant = trek.trackLog.last()
+      assert loggedQuadrant.row == move1QuadRow
+      assert loggedQuadrant.col == move1QuadCol
+
+      trek.updateTrackLog() // Add duplicate, i.e. ship has not changed quadrant
+      assert trek.trackLog.size() == 2 // Duplicate rejected
+    }
+
+    logger.info '< testUpdateTrackLog'
   }
 }


### PR DESCRIPTION
Fixes #203

- Added `trackLog` to `Trek` class for tracking quadrant changes.
- New `Trek` methods: `showHistory` and `updateTrackLog`.
- New history command  in `TrekCli`.
- New `fmtMsgNoln` method in `UiBase` for formatted output without new line.
- Updated `LongRangeScanTest` and `ShortRangeScanTest` due to TestUi changes.
- Add history tests to  `TrekTest` .
- Add new history  message to  `Language.properties` .
- Updates to spelling dictionary